### PR TITLE
Remove duplicated `.vscode/extensions.json` settings

### DIFF
--- a/flake-modules/python-envs-poetry.nix
+++ b/flake-modules/python-envs-poetry.nix
@@ -3,6 +3,7 @@
     ./jobs.nix
     ./common.nix
     ./vscode.nix
+    ./python-vscode.nix
   ];
   options.perSystem = flake-parts-lib.mkPerSystemOption ({ lib, inputs', pkgs, ... }:
     let
@@ -13,11 +14,6 @@
     in
     {
       ml-ops.devcontainer = {
-        nixago.requests.".vscode/extensions.json".data = {
-          "recommendations" = [
-            "ms-python.python"
-          ];
-        };
         devenvShellModule.scripts.import-requirements-to-poetry.exec = ''
           if [ ! -f ./pyproject.toml ]
           then


### PR DESCRIPTION
`ms-python.python` was configured in both `python-vscode.nix` and `python-envs-poetry.nix`. This PR removes one of them.