### PR TITLE
Partially generate `.vscode/settings.json`

### DIFF
--- a/examples/my-project/.gitignore
+++ b/examples/my-project/.gitignore
@@ -4,5 +4,4 @@
 /.devcontainer.json
 
 # nixago: ignore-linked-files
-/.vscode/settings.json
 /.vscode/extensions.json

--- a/examples/my-project/.vscode/settings.json
+++ b/examples/my-project/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "jupyter.debugJustMyCode": false,
+  "python.terminal.activateEnvironment": false
+}

--- a/examples/my-project/flake.lock
+++ b/examples/my-project/flake.lock
@@ -291,10 +291,10 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1694634388,
-        "narHash": "sha256-CvIH5cYPobLRkN/fJIjJr5aK7pOmAIg5i4GhBEWvkPg=",
+        "lastModified": 1698778906,
+        "narHash": "sha256-lhXGd7/ldYMCupfyizdMwh112D5n3rcImKmZOnPRkH8=",
         "ref": "HEAD",
-        "rev": "b8eeae486a8ce6e15013339c811ffc1be47aac55",
+        "rev": "2388b13bb7a395da2ada756e69281118442ce145",
         "shallow": true,
         "type": "git",
         "url": "file:./../.."
@@ -518,11 +518,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689008574,
-        "narHash": "sha256-VFMgyHDiqsGDkRg73alv6OdHJAqhybryWHv77bSCGIw=",
+        "lastModified": 1694767346,
+        "narHash": "sha256-5uH27SiVFUwsTsqC5rs3kS7pBoNhtoy9QfTP9BmknGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a729ce4b1fe5ec4fffc71c67c96aa5184ebb462",
+        "rev": "ace5093e36ab1e95cb9463863491bee90d5a4183",
         "type": "github"
       },
       "original": {

--- a/flake-modules/vscode.nix
+++ b/flake-modules/vscode.nix
@@ -1,10 +1,40 @@
 { flake-parts-lib, lib, inputs, ... }: {
   options.perSystem = flake-parts-lib.mkPerSystemOption {
     config.ml-ops.devcontainer.nixago.requests = {
-      options.".vscode/extensions.json".data.recommendations = lib.mkOption
-        {
+      options = {
+        ".vscode/extensions.json".data.recommendations = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
+        };
+        ".vscode/settings.json" = {
+          data = lib.mkOption {
+            type = lib.types.attrs;
+            default = { };
+          };
+          hook.mode = lib.mkOption {
+            type = lib.types.str;
+            default = "copy";
+          };
+        };
+      };
+
+      config =
+        let
+          settingsJson = ".vscode/settings.json";
+
+          mkRecursiveDefault = value:
+            if builtins.isList value
+            then builtins.map mkRecursiveDefault value
+            else if builtins.isAttrs value
+            then lib.attrsets.mapAttrsRecursive (name_path:mkRecursiveDefault) value
+            else lib.mkDefault value;
+        in
+        {
+          "${settingsJson}".data =
+            if builtins.pathExists "${inputs.self}/${settingsJson}"
+            then mkRecursiveDefault (builtins.fromJSON (builtins.readFile "${inputs.self}/${settingsJson}"))
+            else { }
+          ;
         };
     };
   };


### PR DESCRIPTION
This PR reads existing `.vscode/settings.json` and merges the content with settings from `nix-ml-ops` so that `.vscode/settings.json` can include both manually added settings and settings from `nix-ml-ops` or `flake.nix`.