### PR TITLE
Change the `settings.json` from `lib.attrs` to `lib.attrsOf lib.types.anything`

### DIFF
--- a/examples/my-project/.vscode/settings.json
+++ b/examples/my-project/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.tabSize": 4
   },
   "jupyter.debugJustMyCode": false,
   "python.terminal.activateEnvironment": false

--- a/examples/my-project/flake.lock
+++ b/examples/my-project/flake.lock
@@ -291,10 +291,10 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1698778906,
-        "narHash": "sha256-lhXGd7/ldYMCupfyizdMwh112D5n3rcImKmZOnPRkH8=",
+        "lastModified": 1698785963,
+        "narHash": "sha256-qOpyExBeY6iqYFfPFGPNWwuEU8nPPhlY7ome50mSb/Q=",
         "ref": "HEAD",
-        "rev": "2388b13bb7a395da2ada756e69281118442ce145",
+        "rev": "3476cd272d9b552ab5ab4ed5f8cdcde5cf9d60be",
         "shallow": true,
         "type": "git",
         "url": "file:./../.."

--- a/flake-modules/vscode.nix
+++ b/flake-modules/vscode.nix
@@ -8,7 +8,7 @@
         };
         ".vscode/settings.json" = {
           data = lib.mkOption {
-            type = lib.types.attrs;
+            type = lib.types.attrsOf lib.types.anything;
             default = { };
           };
           hook.mode = lib.mkOption {
@@ -26,7 +26,7 @@
             if builtins.isList value
             then builtins.map mkRecursiveDefault value
             else if builtins.isAttrs value
-            then lib.attrsets.mapAttrsRecursive (name_path:mkRecursiveDefault) value
+            then lib.attrsets.mapAttrs (name: mkRecursiveDefault) value
             else lib.mkDefault value;
         in
         {


### PR DESCRIPTION
According to my test, `lib.attrs` does not recursive merge values, while `lib.attrsOf lib.types.anything` does. This PR switches the type of `settings.json` from `lib.attrs` to `lib.attrsOf lib.types.anything` so that existing nested values would not be discarded.