### PR TITLE
Add `ml-ops.common.pythonPackage`

### DIFF
--- a/examples/devenv-python/.envrc
+++ b/examples/devenv-python/.envrc
@@ -1,0 +1,7 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+
+# Environment variables are cached by direnv, so we don't need Nix's eval-cache.
+# Disable Nix's eval-cache so that we can always see error messages if any.
+use flake --no-eval-cache --show-trace

--- a/examples/devenv-python/.gitignore
+++ b/examples/devenv-python/.gitignore
@@ -1,0 +1,8 @@
+/.direnv/
+/result
+/.devenv/
+/.devcontainer.json
+/.venv/
+
+# nixago: ignore-linked-files
+/.vscode/extensions.json

--- a/examples/devenv-python/README.md
+++ b/examples/devenv-python/README.md
@@ -1,0 +1,21 @@
+This is a project to test `ml-ops` when using Python virtual environment with [devenv](https://devenv.sh/). Unlike the poetry2nix solution, the Python dependencies are not managed by Nix.
+
+## Commands available:
+
+```
+nix flake show
+```
+
+```
+nix develop -c echo OK
+```
+
+```
+nix develop -c python
+```
+
+### List all project-specific command-line tools
+
+```
+nix develop -c ls "${PATH%%:*}"
+```

--- a/examples/devenv-python/flake.lock
+++ b/examples/devenv-python/flake.lock
@@ -1,0 +1,719 @@
+{
+  "nodes": {
+    "conda-channels": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682188392,
+        "narHash": "sha256-5ZTgqNXCb94tqSrB7Zaswa+8AdiNZO+E7XYMtif1q+8=",
+        "owner": "davhau",
+        "repo": "conda-channels",
+        "rev": "8c769055ca1670a202d2024cef5d39901f877416",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "repo": "conda-channels",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nix": "nix",
+        "nixpkgs": [
+          "ml-ops",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1691777852,
+        "narHash": "sha256-DPufHYaJcArEJfuZ234sDXr8qUvqbN7zYSs5yhvU6jA=",
+        "owner": "Preemo-Inc",
+        "repo": "devenv",
+        "rev": "cea2fc8c82d29ab8bd0a3dbad0f8574052aeee8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Preemo-Inc",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "ml-ops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_8": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "ml-ops",
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681265293,
+        "narHash": "sha256-sUoErTMmR9xALl2me7AqpCoLT48LAnFWIDMnNctgARY=",
+        "owner": "Preemo-Inc",
+        "repo": "mach-nix",
+        "rev": "4ce490eb409afb764cdb46803bed8faea8319c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Preemo-Inc",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "mk-shell-bin": {
+      "locked": {
+        "lastModified": 1677004959,
+        "narHash": "sha256-/uEkr1UkJrh11vD02aqufCxtbF5YnhRTIKlx5kyvf+I=",
+        "owner": "rrbutani",
+        "repo": "nix-mk-shell-bin",
+        "rev": "ff5d8bd4d68a347be5042e2f16caee391cd75887",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rrbutani",
+        "repo": "nix-mk-shell-bin",
+        "type": "github"
+      }
+    },
+    "ml-ops": {
+      "inputs": {
+        "conda-channels": "conda-channels",
+        "devenv": "devenv",
+        "flake-parts": "flake-parts",
+        "mach-nix": "mach-nix",
+        "mk-shell-bin": "mk-shell-bin",
+        "nix2container": "nix2container",
+        "nixago": "nixago",
+        "nixos-generators": "nixos-generators",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs_22_05": "nixpkgs_22_05",
+        "poetry-add-requirements-txt": "poetry-add-requirements-txt",
+        "poetry2nix": "poetry2nix",
+        "pypi-deps-db": "pypi-deps-db",
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1699382157,
+        "narHash": "sha256-RLcFL+Br20UwXXDQziUWuaVfsifvyzT44f4iYsSzcFo=",
+        "ref": "HEAD",
+        "rev": "722fb317def17b8c47b5f1579c848b7befff8780",
+        "shallow": true,
+        "type": "git",
+        "url": "file:./../.."
+      },
+      "original": {
+        "ref": "HEAD",
+        "shallow": true,
+        "type": "git",
+        "url": "file:./../.."
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "ml-ops",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1676545802,
+        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "relaxed-flakes",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "ml-ops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677791117,
+        "narHash": "sha256-zL4Fc5133KMqX7zCzcPODaBPEblUfgQt2UccNBm34Pc=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "85670cab354f7df69dd4af097c27cf9bc5826cb2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixago": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixago-exts": "nixago-exts",
+        "nixpkgs": [
+          "ml-ops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688836621,
+        "narHash": "sha256-yKVQMxL9p7zCWUhnGhDzRVT8sDgHoI3V595lBK0C2YA=",
+        "owner": "Preemo-Inc",
+        "repo": "nixago",
+        "rev": "4505d20aa89c659f3c6979a8bcd592405e386117",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Preemo-Inc",
+        "ref": "no-gitignore",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixago-exts": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixago": "nixago_2",
+        "nixpkgs": [
+          "ml-ops",
+          "nixago",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1676070308,
+        "narHash": "sha256-QaJ65oc2l8iwQIGWUJ0EKjCeSuuCM/LqR8RauxZUUkc=",
+        "owner": "nix-community",
+        "repo": "nixago-extensions",
+        "rev": "e5380cb0456f4ea3c86cf94e3039eb856bf07d0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago-extensions",
+        "type": "github"
+      }
+    },
+    "nixago-exts_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_6",
+        "nixago": "nixago_3",
+        "nixpkgs": [
+          "ml-ops",
+          "nixago",
+          "nixago-exts",
+          "nixago",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655508669,
+        "narHash": "sha256-BDDdo5dZQMmwNH/GNacy33nPBnCpSIydWFPZs0kkj/g=",
+        "owner": "nix-community",
+        "repo": "nixago-extensions",
+        "rev": "3022a932ce109258482ecc6568c163e8d0b426aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago-extensions",
+        "type": "github"
+      }
+    },
+    "nixago_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixago-exts": "nixago-exts_2",
+        "nixpkgs": [
+          "ml-ops",
+          "nixago",
+          "nixago-exts",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1676070010,
+        "narHash": "sha256-iYzJIWptE1EUD8VINAg66AAMUajizg8JUYN3oBmb8no=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "d480ba6c0c16e2c5c0bd2122852d6a0c9ad1ed0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "rename-config-data",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixago_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_7",
+        "nixpkgs": [
+          "ml-ops",
+          "nixago",
+          "nixago-exts",
+          "nixago",
+          "nixago-exts",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655405483,
+        "narHash": "sha256-Crd49aZWNrpczlRTOwWGfwBMsTUoG9vlHDKQC7cx264=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "e6a9566c18063db5b120e69e048d3627414e327d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1693701915,
+        "narHash": "sha256-waHPLdDYUOHSEtMKKabcKIMhlUOHPOOPQ9UyFeEoovs=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5af57d3ef9947a70ac86e42695231ac1ad00c25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixos-generators": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "nixpkgs": [
+          "ml-ops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696058303,
+        "narHash": "sha256-eNqKWpF5zG0SrgbbtljFOrRgFgRzCc4++TMFADBMLnc=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "150f38bd1e09e20987feacb1b0d5991357532fb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699113406,
+        "narHash": "sha256-Fhu1yiZcvi6Cp+ioFzlDGTm7VBbbzF/e03od0V5yaNI=",
+        "owner": "Preemo-Inc",
+        "repo": "nixpkgs",
+        "rev": "03e4221db9044c2b06f890ad087ad928eaca9e63",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Preemo-Inc",
+        "ref": "gce-image-uefi-nvme",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_22_05": {
+      "locked": {
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.05",
+        "type": "indirect"
+      }
+    },
+    "poetry-add-requirements-txt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654077719,
+        "narHash": "sha256-BpryyfhKTNPDYIZXHTfHexVPZMhl76L81tsfOGvQKto=",
+        "owner": "tddschn",
+        "repo": "poetry-add-requirements.txt",
+        "rev": "710dde128b3746e7269e423f46f1e0e432c47043",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tddschn",
+        "repo": "poetry-add-requirements.txt",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": [
+          "ml-ops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1683574535,
+        "narHash": "sha256-DEXNDwqfWxtMWVdUgx1N188XWQmu2EUNWwN1f27cNXc=",
+        "owner": "Preemo-Inc",
+        "repo": "poetry2nix",
+        "rev": "55442cc5bf2eb8c30a1e305616a99b6f16b6e243",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Preemo-Inc",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "ml-ops",
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "ml-ops",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1688056373,
+        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682198241,
+        "narHash": "sha256-tnhFetOjyVhI944sCPbv7xiTrMZ3F+qgrq2NCkyYVdk=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "0f67e6ea7384cea09f7dedbc7a69710b22da7cf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ml-ops": "ml-ops"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/devenv-python/flake.nix
+++ b/examples/devenv-python/flake.nix
@@ -1,0 +1,19 @@
+{
+  inputs.ml-ops.url = "git+file:./../..?ref=HEAD&shallow=1";
+  outputs = inputs @ { ml-ops, ... }:
+    ml-ops.lib.mkFlake { inherit inputs; } {
+      imports = [
+        ml-ops.flakeModules.devenvPythonWithLibstdcxx
+        ml-ops.flakeModules.devcontainer
+      ];
+      perSystem = { pkgs, ... }: {
+        ml-ops.devcontainer = {
+          pythonPackage.base-package = pkgs.python310;
+          devenvShellModule.languages.python = {
+            enable = true;
+            venv.enable = true;
+          };
+        };
+      };
+    };
+}

--- a/flake-modules/common.nix
+++ b/flake-modules/common.nix
@@ -6,6 +6,7 @@ topLevel@{ inputs, flake-parts-lib, ... }: {
   flake.flakeModules.common = {
     imports = [
       topLevel.config.flake.flakeModules.nixpkgs
+      inputs.devenv.flakeModule
     ];
     options.perSystem = flake-parts-lib.mkPerSystemOption ({ lib, ... }: {
       config.nixpkgs.config.allowUnsupportedSystem = true;
@@ -32,7 +33,9 @@ topLevel@{ inputs, flake-parts-lib, ... }: {
                   Common config that will be copied to `config.devenv.shells.`*<shell_name>*`.config` for each shell
                 '';
                 default = { };
-                type = lib.types.deferredModule;
+                type = lib.types.deferredModuleWith {
+                  staticModules = [ ];
+                };
               };
               config.devenvShellModule.env = config.environmentVariables;
               config.devenvShellModule.devenv.root = ".";

--- a/flake-modules/devcontainer.nix
+++ b/flake-modules/devcontainer.nix
@@ -6,7 +6,6 @@ topLevel@{ flake-parts-lib, inputs, lib, ... }: {
   flake.flakeModules.devcontainer = {
     imports = [
       topLevel.config.flake.flakeModules.common
-      inputs.devenv.flakeModule
     ];
     options.perSystem = flake-parts-lib.mkPerSystemOption (perSystem @{ system, pkgs, ... }: {
       options.ml-ops.devcontainer = lib.mkOption {

--- a/flake-modules/python-package.nix
+++ b/flake-modules/python-package.nix
@@ -1,0 +1,30 @@
+topLevel@{ flake-parts-lib, lib, inputs, ... }: {
+  imports = [
+    inputs.flake-parts.flakeModules.flakeModules
+    ./common.nix
+    ./overridable-package.nix
+  ];
+  flake.flakeModules.pythonPackage = {
+    imports = [
+      topLevel.config.flake.flakeModules.common
+      topLevel.config.flake.flakeModules.overridablePackage
+    ];
+    options.perSystem = flake-parts-lib.mkPerSystemOption
+      (perSystem@{ pkgs, system, ... }: {
+        options.ml-ops.common = flake-parts-lib.mkDeferredModuleOption (common: {
+          options.pythonPackage = lib.mkOption
+            {
+              default = { };
+              type = lib.types.submoduleWith {
+                modules = [
+                  perSystem.config.ml-ops.overridablePackage
+                ];
+              };
+            };
+          options.devenvShellModule = flake-parts-lib.mkPerSystemOption {
+            languages.python.package = common.config.pythonPackage.overridden-package;
+          };
+        });
+      });
+  };
+}


### PR DESCRIPTION
Since we have upgraded `nixpkgs` in https://github.com/Preemo-Inc/nix-ml-ops/blame/4bd0c871cbb49b87e742e3cd17a7daf96db14033/flake.nix, now the default Python version is 3.11. We need a way to specify the Python version.

We cannot directly specify Python version via `ml-ops.common.devenvShellModule.languages.python.package`, because it would conflict with `flake-modules/devenv-python-with-libstdc++.nix`, which also sets `ml-ops.common.devenvShellModule.languages.python.package`, given that `languages.python.package` can be defined only once.

This PR introduces a new submodule `ml-ops.common.pythonPackage`, which is composable because it allows for multiple `overrideAttrs` with the help of `flake-modules/overridable-package.nix`. See `examples/devenv-python/flake.nix` for how to set the Python base package that would not conflict with `flake-modules/devenv-python-with-libstdc++.nix`.