### PR TITLE
Refactor python-package.nix to use deferred module options for `ml-ops.common`

### DIFF
--- a/flake-modules/devenv-python-with-libstdc++.nix
+++ b/flake-modules/devenv-python-with-libstdc++.nix
@@ -10,13 +10,16 @@ topLevel@{ flake-parts-lib, lib, inputs, ... }: {
     options.perSystem = flake-parts-lib.mkPerSystemOption
       (perSystem@{ pkgs, system, ... }: {
         ml-ops.common.pythonPackage = pythonPackage: {
-          overrideAttrs = lib.mkIf pythonPackage.config.base-package.stdenv.isLinux [
-            (self: super: {
-              env = super.env // {
-                # Link libstdc++ to python interpreter so that packages in manylinux ABI can find it out-of-the-box without LD_LIBRARY_PATH
-                # TODO: Add more libraries here when encountering an ImportError
-                NIX_LDFLAGS = "--no-as-needed -lstdc++ --as-needed ${super.env.NIX_LDFLAGS}";
-              };
+          override = [
+            (old: lib.attrsets.optionalAttrs old.stdenv.isLinux {
+              self = old.self.overrideAttrs
+                (self: super: {
+                  env = super.env // {
+                    # Link libstdc++ to python interpreter so that packages in manylinux ABI can find it out-of-the-box without LD_LIBRARY_PATH
+                    # TODO: Add more libraries here when encountering an ImportError
+                    NIX_LDFLAGS = "--no-as-needed -lstdc++ --as-needed ${super.env.NIX_LDFLAGS}";
+                  };
+                });
             })
           ];
         };

--- a/flake-modules/python-package.nix
+++ b/flake-modules/python-package.nix
@@ -11,20 +11,26 @@ topLevel@{ flake-parts-lib, lib, inputs, ... }: {
     ];
     options.perSystem = flake-parts-lib.mkPerSystemOption
       (perSystem@{ pkgs, system, ... }: {
-        options.ml-ops.common = flake-parts-lib.mkDeferredModuleOption (common: {
-          options.pythonPackage = lib.mkOption
-            {
-              default = { };
-              type = lib.types.submoduleWith {
-                modules = [
-                  perSystem.config.ml-ops.overridablePackage
-                ];
-              };
-            };
-          options.devenvShellModule = flake-parts-lib.mkPerSystemOption {
-            languages.python.package = common.config.pythonPackage.overridden-package;
+        options.ml-ops.common = lib.mkOption {
+          type = lib.types.deferredModuleWith {
+            staticModules = [
+              (common: {
+                options.pythonPackage = lib.mkOption {
+                  default = { };
+                  type = lib.types.submoduleWith {
+                    modules = [
+                      {
+                        imports = [ perSystem.config.ml-ops.overridablePackage ];
+                        config.base-package = lib.mkDefault pkgs.python3;
+                      }
+                    ];
+                  };
+                };
+                config.devenvShellModule.languages.python.package = common.config.pythonPackage.overridden-package;
+              })
+            ];
           };
-        });
+        };
       });
   };
 }


### PR DESCRIPTION
This PR fixes "Module imports can't be nested lists" error