### PR TITLE
Add `mountOptions` option for nfs

### DIFF
--- a/flake-modules/aks-credential.nix
+++ b/flake-modules/aks-credential.nix
@@ -23,8 +23,8 @@ topLevel@{ flake-parts-lib, inputs, lib, ... }: {
                               [
                                 (previousPackage: previousPackage.overrideAttrs
                                   (previousAttrs: {
-                                    aksCluster = kubernetes.config.aks.cluster;
-                                    aksResourceGroup = kubernetes.config.aks.resourcegroup;
+                                    aksCluster = aks.cluster;
+                                    aksResourceGroup = aks.resourcegroup;
                                     buildCommand = ''
                                       # TODO(bo@preemo.io, 11/09/2023): Supports credentials other than managed identity. See https://nixos.wiki/wiki/Comparison_of_secret_managing_schemes
                                       az login --identity
@@ -83,28 +83,26 @@ topLevel@{ flake-parts-lib, inputs, lib, ... }: {
 
                       config.pushImage.pipe =
                         lib.mkIf (kubernetes.config.aks != null)
-                          (lib.mkDerivedConfig
-                            kubernetes.options.aks
-                            (aks: [
-                              (previousPackage: previousPackage.overrideAttrs
-                                (previousAttrs: {
-                                  aksRegistryName = aks.registryName;
+                          (lib.mkDerivedConfig kubernetes.options.aks (aks: [
+                            (previousPackage: previousPackage.overrideAttrs
+                              (previousAttrs: {
+                                aksRegistryName = aks.registryName;
 
-                                  buildCommand = ''
-                                    # TODO(bo@preemo.io, 11/09/2023): Supports credentials other than managed identity. See https://nixos.wiki/wiki/Comparison_of_secret_managing_schemes
-                                    az login --identity
+                                buildCommand = ''
+                                  # TODO(bo@preemo.io, 11/09/2023): Supports credentials other than managed identity. See https://nixos.wiki/wiki/Comparison_of_secret_managing_schemes
+                                  az login --identity
 
-                                    export skopeoCopyArgs="$(printf "%q " --dest-username 00000000-0000-0000-0000-000000000000 --dest-password "$(az acr login --name "$aksRegistryName" --expose-token --output tsv --query accessToken)")"
+                                  export skopeoCopyArgs="$(printf "%q " --dest-username 00000000-0000-0000-0000-000000000000 --dest-password "$(az acr login --name "$aksRegistryName" --expose-token --output tsv --query accessToken)")"
 
-                                    ${previousAttrs.buildCommand}
-                                  '';
-                                  nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
-                                    # pkgs.cacert
-                                    pkgs.azure-cli
-                                  ];
-                                })
-                              )
-                            ]));
+                                  ${previousAttrs.buildCommand}
+                                '';
+                                nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
+                                  # pkgs.cacert
+                                  pkgs.azure-cli
+                                ];
+                              })
+                            )
+                          ]));
 
                       config.helmUpgrade.imports = [
                         authModule

--- a/flake-modules/volume-mount-nfs.nix
+++ b/flake-modules/volume-mount-nfs.nix
@@ -15,6 +15,10 @@ topLevel@{ inputs, flake-parts-lib, ... }: {
           default = { };
           type = lib.types.attrsOf (lib.types.submoduleWith {
             modules = [{
+              options.mountOptions = lib.mkOption {
+                default = [ "rw" "intr" "nolock" ];
+                type = lib.types.listOf lib.types.str;
+              };
               options.path = lib.mkOption {
                 example = "/ml_data";
                 type = lib.types.str;
@@ -61,13 +65,17 @@ topLevel@{ inputs, flake-parts-lib, ... }: {
                       ]
                     }
                     ${
-                      lib.strings.escapeShellArgs [
-                        "mount.nfs"
-                        "-o"
-                        "rw,intr,nolock"
-                        "${config.server}:${config.path}"
-                        config._module.args.name
-                      ]
+                      lib.strings.escapeShellArgs (
+                        [
+                          "mount.nfs"
+                        ] ++ lib.lists.optionals (config.mountOptions != []) [
+                          "-o"
+                          (lib.strings.concatStringsSep "," config.mountOptions)
+                        ] ++ [
+                          "${config.server}:${config.path}"
+                          config._module.args.name
+                        ]
+                      )
                     }
                   '';
                 };


### PR DESCRIPTION
According to [Azure's this document](https://learn.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to), we can mount Azure Blob Storage via NFS protocol, while some special mount options are required.

This PR adds `mountOptions` option for nfs mounting so that we can specify the options required by Azure.