### PR TITLE
Make `gke` option nullable

### DIFF
--- a/flake-modules/gke-credential.nix
+++ b/flake-modules/gke-credential.nix
@@ -49,13 +49,20 @@ topLevel@{ flake-parts-lib, inputs, lib, ... }: {
                       };
                     in
                     {
-
-                      options.gke.region = lib.mkOption {
-                        type = lib.types.str;
-                      };
-
-                      options.gke.cluster = lib.mkOption {
-                        type = lib.types.str;
+                      options.gke = lib.mkOption {
+                        default = null;
+                        type = lib.types.nullOr (lib.types.submoduleWith {
+                          modules = [
+                            {
+                              options.region = lib.mkOption {
+                                type = lib.types.str;
+                              };
+                              options.cluster = lib.mkOption {
+                                type = lib.types.str;
+                              };
+                            }
+                          ];
+                        });
                       };
 
                       config.pushImage.pipe =


### PR DESCRIPTION
We added a condition in #16 to skip GKE setting when `gke` config is `null`. Unfortunately `gke` was always non-null, therefore GKE setting would never actually be skipped.

This PR sets the default value of `gke` to `null` so that it can be skipped properly