### PR TITLE
Generate Helm charts that support `mountOptions`

### DIFF
--- a/flake-modules/kubernetes.nix
+++ b/flake-modules/kubernetes.nix
@@ -33,7 +33,7 @@ topLevel@{ flake-parts-lib, inputs, lib, ... }: {
           };
 
           lib.pathToKubernetesName = lib.mkOption {
-            type = lib.types.functionTo lib.types.string;
+            type = lib.types.functionTo lib.types.str;
             default = path: lib.trivial.pipe path [
               (builtins.split "/")
               (builtins.filter (s: builtins.isString s && s != ""))

--- a/flake-modules/volume-mount-nfs.nix
+++ b/flake-modules/volume-mount-nfs.nix
@@ -42,6 +42,7 @@ topLevel@{ inputs, flake-parts-lib, ... }: {
                     nfs = {
                       inherit (config) server path;
                     };
+                    mountOptions = config.mountOptions;
                   };
                 };
               })


### PR DESCRIPTION
We previously mounted NFS in Job or Deployment manifests as documented [here](https://kubernetes.io/docs/concepts/storage/volumes/#nfs). However, NFS `volumes` configured in Job or Deployment manifests does not support `mountOptions`.

This PR creates separate manifests of `PersistentVolumeClaim` and `PersistentVolume`, which support `mountOptions`, so that we can specify the `mountOptions` to mount Azure Blob Storage.